### PR TITLE
change in cache function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -95,7 +95,6 @@ Collate:
     'agent.R'
     'SELES.R'
     'cache.R'
-    'cache_test.R'
     'check.R'
     'checkpoint.R'
     'copy.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -95,6 +95,7 @@ Collate:
     'agent.R'
     'SELES.R'
     'cache.R'
+    'cache_test.R'
     'check.R'
     'checkpoint.R'
     'copy.R'

--- a/R/cache.R
+++ b/R/cache.R
@@ -99,9 +99,15 @@
 #' @param cacheRepo	A repository used for storing cached objects. This is optional
 #'                  if \code{Cache} is used inside a SpaDES module.
 #'
-#' @param makeCopy Logical. Indicate if
+#' @param makeCopy Logical. If TRUE, a copy of the downloaded files will be stored in the cacheRepo/gallery.
+#'                 This allow to recover a copy faster than running the function if files are not found locally.
+#'                 Only work when cache run for the first time for now.
 #'
-#' @param sideEffect
+#' @param sideEffect A logical argument indicating if downloaded files are found locally using
+#'                   filename and checksum. When absent, files are recover from the copy stored in cacheRepo/gallery.
+#'
+#' @param quick A logical argument indicating if checksum should be made on file (FALSE) or on character string
+#'              representing the combination of the filename and its size (TRUE). Default is TRUE
 #'
 #' @inheritParams digest::digest
 #'

--- a/R/cache.R
+++ b/R/cache.R
@@ -99,6 +99,10 @@
 #' @param cacheRepo	A repository used for storing cached objects. This is optional
 #'                  if \code{Cache} is used inside a SpaDES module.
 #'
+#' @param makeCopy Logical. Indicate if
+#'
+#' @param sideEffect
+#'
 #' @inheritParams digest::digest
 #'
 #' @return As with \code{\link[archivist]{cache}}, the return is either the return
@@ -173,7 +177,7 @@
 setGeneric("Cache", signature = "...",
            function(FUN, ..., notOlderThan = NULL,
                     objects = NULL, outputObjects = NULL, algo = "xxhash32",
-                    cacheRepo = NULL) {
+                    cacheRepo = NULL, sideEffect= FALSE, makeCopy = FALSE, quick) {
              archivist::cache(cacheRepo, FUN, ..., notOlderThan, algo)
 })
 
@@ -182,10 +186,13 @@ setGeneric("Cache", signature = "...",
 setMethod(
   "Cache",
   definition = function(FUN, ..., notOlderThan, objects, outputObjects,
-                        algo, cacheRepo = NULL) {
+                        algo, cacheRepo = NULL, sideEffect= FALSE, makeCopy = FALSE, quick) {
     tmpl <- list(...)
-
+    browser()
     if (missing(notOlderThan)) notOlderThan <- NULL
+
+    if (missing(quick)) quick <- TRUE
+
     # These three lines added to original version of cache in archive package
     wh <- which(sapply(tmpl, function(x) is(x, "simList")))
     if (is.null(cacheRepo)) {
@@ -221,6 +228,7 @@ setMethod(
       if (length(wh) > 0) tmpl[wh] <- lapply(tmpl[wh], function(xx) makeDigestible(xx, objects))
     }
 
+
     if (isS4(FUN)) {
       # Have to extract the correct dispatched method
       firstElems <- strsplit(showMethods(FUN, inherited = TRUE, printTo = FALSE), split = ", ")
@@ -247,7 +255,18 @@ setMethod(
     if (length(whRas) > 0) tmpl[whRas] <- lapply(tmpl[whRas], makeDigestible)
     if (length(whFun) > 0) tmpl[whFun] <- lapply(tmpl[whFun], format)
     if (!is.null(tmpl$progress)) if (!is.na(tmpl$progress)) tmpl$progress <- NULL
+    #0
+    currentdirList <- dir(cacheRepo)
+    currentFileList <- currentdirList[ !file.info(file.path(cacheRepo,currentdirList))$isdir ]
+    if (quick){
+      sizeCurrentFiles <- lapply(currentFileList, function(x) {list(x, file.info(x)[,"size"])})
+      cacheCurrentFiles <- lapply(sizeCurrentFiles, function(x) {digest::digest(x, algo = algo)})
+    } else {
+      cacheCurrentFiles <- lapply(currentFileList, function(x) {digest::digest(file = file.path(cacheRepo,x), algo = algo)})
+    }
+    names(cacheCurrentFiles)<-currentFileList
 
+    #1
     outputHash <- digest::digest(tmpl, algo = algo)
     localTags <- showLocalRepo(cacheRepo, "tags")
     isInRepo <- localTags[localTags$tag == paste0("cacheId:", outputHash), , drop = FALSE]
@@ -262,6 +281,22 @@ setMethod(
 
         out <- loadFromLocalRepo(isInRepo$artifact[lastOne],
                                  repoDir = cacheRepo, value = TRUE)
+
+        if (sideEffect){
+          cachedFileNames <- sub(":.*", "", attributes(out)$cacheFileList)
+          repoFrom = file.path(cacheRepo, "gallery")
+          for (i in 1:length(cachedFileNames)){
+            if(!file.exists(file.path(cacheRepo, cachedFileNames[i]))) {
+              file.copy(file.path(cacheRepo, cachedFileNames[i]), repoFrom)
+            } else {
+              currentFilesize <- paste0(names(cacheCurrentFiles), ":", cacheCurrentFiles)
+              if (attributes(out)$cacheFileList[i] != currentFilesize[i]) {
+                file.copy(file.path(cacheRepo, currentFileNames[i]), repoFrom)
+              }
+            }
+          }
+        }
+
         #if(!is(out, "simList")) {
           if (length(wh) > 0) {
             simListOut <- out # gets all items except objects in list(...)
@@ -276,6 +311,7 @@ setMethod(
 
             return(simListOut)
           }
+
         #}
 
         return(out)
@@ -288,6 +324,9 @@ setMethod(
     output <- do.call(FUN, list(...))
     attr(output, "tags") <- paste0("cacheId:", outputHash)
     attr(output, "call") <- ""
+    #0
+    attr(output, "cacheFileList") <- paste0(names(cacheCurrentFiles), ":", cacheCurrentFiles)
+    #1
     if (isS4(FUN)) attr(output, "function") <- FUN@generic
 
     if (is(output, "simList")) {
@@ -297,6 +336,9 @@ setMethod(
         list2env(mget(outputObjects, envir = output@.envir), envir = outputToSave@.envir)
         attr(outputToSave, "tags") <- attr(output, "tags")
         attr(outputToSave, "call") <- attr(output, "call")
+        #0
+        attr(outputToSave, "endFileList") <- attr(output, "endFileList")
+        #1
         if (isS4(FUN))
           attr(outputToSave, "function") <- attr(output, "function")
       } else {
@@ -320,6 +362,15 @@ setMethod(
       } else {
         TRUE
       }
+    }
+    if (makeCopy){
+      endFileList <- dir(cacheRepo)
+      dwdFile <- setdiff(endFileList, currentdirList)
+      repoTo = file.path(cacheRepo, "gallery")
+      for (i in 1:length(output$paths)){
+        file.copy(output$paths[i], repoTo)
+      }
+
     }
     return(output)
 })

--- a/R/cache_test.R
+++ b/R/cache_test.R
@@ -1,0 +1,51 @@
+#' To run cache
+#'
+#' This temp script is to try modification made on cache
+#'
+#' @param sim   bleblebleb
+#'
+#' @return Invisibly returns the cropped, projected, and masked raster.
+#'
+#' @importFrom raster raster
+#' @importFrom utils download.file unzip
+#' @export
+#' @docType methods
+#'
+#'
+testcache <- function(sim) {
+  myGreatFuncion <- function(sim) {
+    data2 <- basename(sim$url)
+    download.file(sim$url, file.path(paths$outputPath, data2))
+    unzip <- unzip(file.path(paths$outputPath, data2), exdir = file.path(paths$outputPath, file_path_sans_ext(data2)))
+    sim$file<- list.files(file.path(outdir, file_path_sans_ext(data2)), pattern="\\.tif$")
+    return(sim)
+  }
+  myGreatFuncion1 <- function(sim) {
+    sim$rast <-raster(file.path(paths$outputPath,sim$file,sim$file))
+    return(sim)
+  }
+  sim <- myGreatFuncion(sim)
+  sim <- myGreatFuncion1(sim)
+
+  return(sim)
+}
+
+outdir<-tempdir()
+times <- list(start = 2010.0, end = 2020.0, timeunit = "year")
+parameters <- list()
+modules <- list()
+paths <- list(outputPath=outdir)
+sim <- SpaDES::simInit(times = times, params = parameters, modules = modules, paths = paths)
+#sim$url<-"ftp://ftp.agrc.utah.gov/Imagery/LandForm/"
+sim$url<- "http://ftp.geogratis.gc.ca/pub/nrcan_rncan/image/landsat_7/geobase_ortho/geotiff/lcc/004026/004026_0100_010805_l7_6l_lcc00.tif.zip"
+
+
+
+#mySim<- testcache(sim)
+mySim<-SpaDES::Cache(cacheRepo= outdir, testcache, Copy(sim), sideEffect = TRUE, makeCopy = TRUE)
+
+
+#mySim<-system.time(SpaDES::Cache(cacheRepo=outdir, testcache, sim, sideEffect = FALSE))
+
+#system.time(archivist::cache(cacheRepo, testcache(sim)))
+

--- a/tests/testthat/test-cache_MH1.R
+++ b/tests/testthat/test-cache_MH1.R
@@ -1,0 +1,40 @@
+test_that("test-cache", {
+  library(tools)
+  library(raster)
+
+  on.exit({
+    detach("package:tools")
+    detach("package:raster")
+  }, add = TRUE)
+
+  outdir<-tempdir()
+  sim <- SpaDES::simInit(times = list(start = 2010.0, end = 2020.0, timeunit = "year"),
+                         params = list(),
+                         modules = list(),
+                         paths = list(outputPath=outdir))
+
+  sim$url<- "http://ftp.geogratis.gc.ca/pub/nrcan_rncan/image/landsat_7/geobase_ortho/geotiff/lcc/004026/004026_0100_010805_l7_6l_lcc00.tif.zip"
+  sim$path <- tempdir()
+
+  testcache <- function(sim) {
+    myGreatFuncion <- function(sim) {
+      data2 <- basename(sim$url)
+      download.file(sim$url, file.path(sim$path, data2))
+      unzip <- unzip(file.path(sim$path, data2), exdir = sim$path)
+      sim$file<- list.files(sim$path, pattern="\\.tif$")
+      return(sim)
+    }
+    myGreatFuncion1 <- function(sim) {
+      sim$rast <-raster(file.path(sim$path,sim$file))
+      return(sim)
+    }
+  sim <- myGreatFuncion(sim)
+  sim <- myGreatFuncion1(sim)
+  return(sim)
+  }
+  #testcache(Copy(sim))
+  mySim<-SpaDES::Cache(cacheRepo= outdir, testcache, Copy(sim), sideEffect = TRUE, makeCopy = TRUE, quick = FALSE)
+
+  expect_that(file.exists(file.path(mySim$path, basename(sim$url))), is_true())
+  expect_that(is(mySim$rast, "RasterLayer"), is_true())
+})


### PR DESCRIPTION
Hi! This is  my first pull request. Hope I didn't create a bug anywhere. I  added 3 functionalities to the cache function (sideEffect, makeCopy and quick).  I change the url. The file to download in the example is 4Mo. To run cache, use cache.test.R in  the R directory (next to cache.R). 

To discuss:
-For now makeCopy only work the first time cache is running. I could add it to make it able to run inside the    if (nrow(isInRepo) > 0). 
- sideEffect check the existence of downloaded files locally, if not, they take it from cacheRepo/gallery. I didn't implement it so it would run the do.call if the files are missing from cacheRepo/gallery because makeCopy = FALSE the first time cache was run.  
